### PR TITLE
Allow usage of ArrayBuffer as request payload

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -1,8 +1,10 @@
 import { AxiosRequestConfig, AxiosPromise } from 'axios';
 import { arrayBufferToDataURL, isArrayBuffer } from './utils';
 
-function filterUnsupportedConfig(config: AxiosRequestConfig) {
-  const unsupportedConfigs = [
+function filterUnsupportedConfig(
+  config: AxiosRequestConfig
+): Partial<AxiosRequestConfig> {
+  const unsupportedConfigs: string[] = [
     'paramsSerializer',
     'onUploadProgress',
     'onDownloadProgress',
@@ -25,14 +27,12 @@ function filterUnsupportedConfig(config: AxiosRequestConfig) {
       return acc;
     }, {});
 
-  if (isArrayBuffer(ArrayBuffer, filtered.data)) {
+  if (isArrayBuffer(filtered.data)) {
     filtered.data = arrayBufferToDataURL(filtered.data);
   }
 
   return filtered;
 }
-
-
 
 export function adapter(config: AxiosRequestConfig): AxiosPromise {
   return new Promise((resolve, reject) => {

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -1,4 +1,5 @@
 import { AxiosRequestConfig, AxiosPromise } from 'axios';
+import { arrayBufferToDataURL, isArrayBuffer } from './utils';
 
 function filterUnsupportedConfig(config: AxiosRequestConfig) {
   const unsupportedConfigs = [
@@ -7,7 +8,7 @@ function filterUnsupportedConfig(config: AxiosRequestConfig) {
     'onDownloadProgress',
     'cancelToken'
   ];
-  const filtered = Object.keys(config)
+  const filtered: Partial<AxiosRequestConfig> = Object.keys(config)
     .filter((key) => {
       const inBlackList = unsupportedConfigs.indexOf(key) !== -1;
       if (inBlackList) {
@@ -24,8 +25,14 @@ function filterUnsupportedConfig(config: AxiosRequestConfig) {
       return acc;
     }, {});
 
+  if (isArrayBuffer(ArrayBuffer, filtered.data)) {
+    filtered.data = arrayBufferToDataURL(filtered.data);
+  }
+
   return filtered;
 }
+
+
 
 export function adapter(config: AxiosRequestConfig): AxiosPromise {
   return new Promise((resolve, reject) => {

--- a/src/registerMessageHandler.ts
+++ b/src/registerMessageHandler.ts
@@ -1,9 +1,15 @@
 import axios from 'axios';
+import { dataURLToArrayBuffer, isArrayBufferDataUrl } from './utils';
 
 export function registerMessageHandler() {
   chrome.runtime.onMessage.addListener((request, _, sendResponse) => {
     if (request.name === 'axiosMessagingAdapterRequest') {
       // perform axios request in the background script
+
+      if (isArrayBufferDataUrl(request.config.data)) {
+        request.config.data = dataURLToArrayBuffer(request.config.data);
+      }
+
       axios(request.config)
         .then((response) => sendResponse({ response }))
         .catch((error) => sendResponse({ error }));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,39 @@
+export function isArrayBuffer(type, val) {
+  // @ts-ignore
+  // eslint-disable-next-line
+  return ![, null].includes(val) && val.constructor === type;
+}
+
+export function isArrayBufferDataUrl(data: string) {
+  const regex = /^data:encoded-array-buffer(;base64)?,([a-z0-9!$&',()*+;=\-._~:@\/?%\s]*?)$/i;
+
+  return regex.test((data || '').trim());
+}
+
+export function arrayBufferToDataURL(buffer: ArrayBuffer) {
+  return `data:encoded-array-buffer;base64,${arrayBufferToBase64(buffer)}`;
+}
+
+export function dataURLToArrayBuffer(data: string) {
+  return base64ToArrayBuffer(data.substring(data.indexOf(',') + 1));
+}
+
+function arrayBufferToBase64(buffer) {
+  var binary = '';
+  var bytes = new Uint8Array(buffer);
+  var len = bytes.byteLength;
+  for (var i = 0; i < len; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return window.btoa(binary);
+}
+
+function base64ToArrayBuffer(base64) {
+  var binary_string = window.atob(base64);
+  var len = binary_string.length;
+  var bytes = new Uint8Array(len);
+  for (var i = 0; i < len; i++) {
+    bytes[i] = binary_string.charCodeAt(i);
+  }
+  return bytes.buffer;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,38 +1,38 @@
-export function isArrayBuffer(type, val) {
-  // @ts-ignore
-  // eslint-disable-next-line
-  return ![, null].includes(val) && val.constructor === type;
+export function isArrayBuffer(data): boolean {
+  return (
+    data !== undefined && data !== null && data.constructor === ArrayBuffer
+  );
 }
 
-export function isArrayBufferDataUrl(data: string) {
-  const regex = /^data:encoded-array-buffer(;base64)?,([a-z0-9!$&',()*+;=\-._~:@\/?%\s]*?)$/i;
-
-  return regex.test((data || '').trim());
+export function isArrayBufferDataUrl(data: string): boolean {
+  return (data || '').trim().startsWith('data:encoded-array-buffer;base64,');
 }
 
-export function arrayBufferToDataURL(buffer: ArrayBuffer) {
+export function arrayBufferToDataURL(buffer: ArrayBuffer): string {
   return `data:encoded-array-buffer;base64,${arrayBufferToBase64(buffer)}`;
 }
 
-export function dataURLToArrayBuffer(data: string) {
+export function dataURLToArrayBuffer(data: string): ArrayBuffer {
   return base64ToArrayBuffer(data.substring(data.indexOf(',') + 1));
 }
 
-function arrayBufferToBase64(buffer) {
-  var binary = '';
-  var bytes = new Uint8Array(buffer);
-  var len = bytes.byteLength;
-  for (var i = 0; i < len; i++) {
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  const len = bytes.byteLength;
+  let binary = '';
+
+  for (let i = 0; i < len; i++) {
     binary += String.fromCharCode(bytes[i]);
   }
   return window.btoa(binary);
 }
 
-function base64ToArrayBuffer(base64) {
-  var binary_string = window.atob(base64);
-  var len = binary_string.length;
-  var bytes = new Uint8Array(len);
-  for (var i = 0; i < len; i++) {
+function base64ToArrayBuffer(base64: string): ArrayBuffer {
+  const binary_string = window.atob(base64);
+  const len = binary_string.length;
+  let bytes = new Uint8Array(len);
+
+  for (let i = 0; i < len; i++) {
     bytes[i] = binary_string.charCodeAt(i);
   }
   return bytes.buffer;


### PR DESCRIPTION
If the request data is of type ArrayBuffer, convert it to a bas64 dataUrl. On recieving this dataUrl in the Message Listener and before sending the actual axios request, convert it back into an ArrayBuffer.